### PR TITLE
delete: dish in menu id

### DIFF
--- a/spec/open-api.yaml
+++ b/spec/open-api.yaml
@@ -569,13 +569,10 @@ components:
       properties:
         id:
           type: string
-        menuId:
-          type: string
         name:
           type: string
       required:
         - id
-        - menuId
         - name
 
     MenuWithDishes:


### PR DESCRIPTION
[37](https://github.com/ogurilab/school-lunch-api/issues/37) に伴いdishがmenuIDを持たなくなったので消去した。